### PR TITLE
Feat/svg map compatibility high relevance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ You can use the following methods:
 | `.zoomToAt(2, { x: 100, y: 50 })` | Zoom to a level while keeping a content point fixed. Pass `{ x, y, percent: true }` for percent coordinates. Pass `true` as third argument to zoom instantly |
 | `.reset()` | Reset to the initial zoom and pan. Pass `true` for instant reset, or an options object with `zoom`, `panX`, `panY`, `center`, and `instant` |
 | `.resize()` | Recalculate bounds after the wrapper or panZoom element changes size |
+| `.destroy()` | Remove all event listeners. Call before creating a new instance on the same wrapper and panZoom element |
 
 ### E.g.
 
@@ -125,6 +126,20 @@ var myDomPanZoom = new domPanZoom({
 });
 
 myDomPanZoom.panTo(20, 80);
+```
+
+### Replacing an instance
+
+If you create a new domPanZoom on the same DOM elements, call `destroy()` on the old instance first. Otherwise event listeners stack up and options on the new instance (such as `zoomEnabled`) may appear to be ignored.
+
+```javascript
+myDomPanZoom.destroy();
+
+myDomPanZoom = new domPanZoom({
+  wrapperElement: '#my-wrapper',
+  panZoomElement: '#my-container',
+  zoomEnabled: false
+});
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -66,13 +66,17 @@ You can pass the following options into domPanZoom:
 | Option | Default |  |
 | --- | --- | --- |
 | `center` | `true` | Start with a centered position. This option overrides `initalPanX` and `initialPanY` |
-| `bounds` | `cover` | Set this option to `'contain'` or `'cover'` to limit the boundries of the panZoomElement to the wrapperElement. This works similar to the CSS property background-size: contain / cover. Setting this option might effect the option minZoom |
+| `bounds` | `'contain'` | Set this option to `'contain'` or `'cover'` to limit the boundries of the panZoomElement to the wrapperElement. This works similar to the CSS property background-size: contain / cover. Setting this option might effect the option minZoom |
 | `minZoom` | `0.1` | Minimum zoom, `0.5` would be half the original size |
 | `maxZoom` | `10` | Maximum zoom, `2` would be double the original size |
+| `panEnabled` | `true` | Allow user drag/touch panning |
+| `zoomEnabled` | `true` | Allow user wheel/pinch/double-click zooming |
 | `panStep` | `10` | How many percent to pan by default with the panning methods panLeft, panRight, panUp and panDown |
 | `zoomStep` | `50` | How many percent to zoom by default with the methods zoomIn and zoomOut |
-| `zoomWheelSpeed` | `1` | The speed in which to zoom when using the mouse wheel |
-| `initialZoom` | `1` | Initial zoom level |
+| `zoomSpeedWheel` | `1` | The speed in which to zoom when using the mouse wheel |
+| `mouseWheelRequiresKey` | `false` | When `true`, wheel zoom requires alt, control, meta, or shift. Pass a function for custom checks |
+| `dblClickZoomEnabled` | `false` | Zoom in at the cursor position on double-click |
+| `initialZoom` | `'contain'` | Initial zoom level, or `'contain'` / `'cover'` to fit bounds |
 | `initialPanX` | `0` | Initial horizontal pan in percent |
 | `initialPanY` | `0` | Initial vertical pan in percent |
 | `transitionSpeed` | `400` | Transition speed in milliseconds, higher values are slower |
@@ -108,6 +112,9 @@ You can use the following methods:
 | `.center()` | Pan to centered position. Pass `true` to center instantly, e.g. `.center(true)` |
 | `.zoomIn()`<br>`.zoomOut()` | Zoom in and out. You can pass a number to zoom a specific amount (in percent). Pass `true` as first or second argument to zoom instantly, e.g. `.zoomIn(20)`, `.zoomIn(true)`, `.zoomIn(50, true)` |
 | `.zoomTo(2)` | Zoom to a specific zoom level. Pass `true` as a second argument to zoom instantly, e.g. `.zoomTo(2, true)` |
+| `.zoomToAt(2, { x: 100, y: 50 })` | Zoom to a level while keeping a content point fixed. Pass `{ x, y, percent: true }` for percent coordinates. Pass `true` as third argument to zoom instantly |
+| `.reset()` | Reset to the initial zoom and pan. Pass `true` for instant reset, or an options object with `zoom`, `panX`, `panY`, `center`, and `instant` |
+| `.resize()` | Recalculate bounds after the wrapper or panZoom element changes size |
 
 ### E.g.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,47 @@
     "": {
       "name": "dom-pan-zoom",
       "version": "0.1.4",
+      "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^0.4.4",
-        "rollup": "^4.54.0"
+        "happy-dom": "^20.10.6",
+        "rollup": "^4.54.0",
+        "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -62,6 +99,317 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "16.0.3",
@@ -442,6 +790,42 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -449,12 +833,162 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -469,6 +1003,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -476,10 +1020,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -493,12 +1067,70 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -523,6 +1155,25 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/hasown": {
@@ -561,6 +1212,322 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -568,10 +1535,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -579,6 +1560,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/randombytes": {
@@ -610,6 +1620,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
     "node_modules/rollup": {
@@ -685,6 +1729,13 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/smob": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
@@ -702,6 +1753,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -712,6 +1773,20 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -743,6 +1818,282 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,15 @@
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w",
-    "prepublishOnly": "npm run build && node test/assets.js"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build && npm test && node test/assets.js"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^0.4.4",
-    "rollup": "^4.54.0"
+    "happy-dom": "^20.10.6",
+    "rollup": "^4.54.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/src/core/domPanZoom.js
+++ b/src/core/domPanZoom.js
@@ -546,6 +546,48 @@ export default class domPanZoom {
     return this.zoom;
   }
 
+  // Reset to the initial zoom and pan position
+  reset(arg) {
+    let instant = false;
+    let zoom = this.options.initialZoom;
+    let panX = this.options.initialPanX;
+    let panY = this.options.initialPanY;
+    let useCenter = this.options.center;
+
+    if (typeof arg === 'boolean') {
+      instant = arg;
+    } else if (arg && typeof arg === 'object') {
+      instant = arg.instant === true;
+      if (arg.zoom !== undefined) {
+        zoom = arg.zoom;
+      }
+      if (arg.panX !== undefined) {
+        panX = arg.panX;
+        useCenter = false;
+      }
+      if (arg.panY !== undefined) {
+        panY = arg.panY;
+        useCenter = false;
+      }
+      if (arg.center !== undefined) {
+        useCenter = arg.center;
+      }
+    }
+
+    this.zoom = this.sanitizeZoom(zoom);
+
+    if (useCenter) {
+      this.center(true, true);
+    } else {
+      this.panTo(panX, panY, true, true);
+    }
+
+    this.setPosition(instant);
+    this.fireEvent('onZoom', this.getPosition());
+    this.fireEvent('onPan', this.getPosition());
+    return this;
+  }
+
   // Zoom to
   zoomTo(zoom, instant) {
     // Sanitize zoom

--- a/src/core/domPanZoom.js
+++ b/src/core/domPanZoom.js
@@ -126,7 +126,7 @@ export default class domPanZoom {
       return;
     }
 
-    wrapper.style.cursor = this.options.panEnabled ? 'grab' : null;
+    wrapper.style.cursor = this.options.panEnabled ? 'grab' : '';
   }
 
   // Check whether wheel zoom is allowed for the current event
@@ -743,7 +743,7 @@ export default class domPanZoom {
 
     // Calculate nextZoom
     const currentZoom = this.zoom;
-    const zoomStep = (100 + step) / 100;
+    let zoomStep = (100 + step) / 100;
     if (direction === 'out') {
       zoomStep = 1 / zoomStep;
     }

--- a/src/core/domPanZoom.js
+++ b/src/core/domPanZoom.js
@@ -421,6 +421,32 @@ export default class domPanZoom {
     };
   }
 
+  // Get the offset for zooming while keeping a content point fixed on screen
+  getContentPointOffsetToCenter(contentX, contentY) {
+    const wrapper = this.getWrapper();
+    const container = this.getContainer();
+    const diffX = wrapper.clientWidth - container.clientWidth;
+    const diffY = wrapper.clientHeight - container.clientHeight;
+    const centerX = diffX * 0.5;
+    const centerY = diffY * 0.5;
+
+    const pointInWrapperX = container.offsetLeft + contentX;
+    const pointInWrapperY = container.offsetTop + contentY;
+
+    const offsetToCenter = {
+      x: (wrapper.clientWidth / 2 - pointInWrapperX) * -1,
+      y: (wrapper.clientHeight / 2 - pointInWrapperY) * -1
+    };
+
+    const offsetX = this.x - centerX - offsetToCenter.x;
+    const offsetY = this.y - centerY - offsetToCenter.y;
+
+    return {
+      x: offsetX,
+      y: offsetY
+    };
+  }
+
   // Get the distance between two touch events
   getTouchEventsDistance(ev1, ev2) {
     return Math.abs(Math.hypot(ev1.pageX - ev1.pageX, ev1.pageY - ev2.pageY));
@@ -605,6 +631,30 @@ export default class domPanZoom {
     this.fireEvent('onZoom', this.getPosition());
 
     // Return instance
+    return this;
+  }
+
+  // Zoom to a level while keeping a content point fixed on screen
+  zoomToAt(zoom, point, instant) {
+    zoom = this.sanitizeZoom(zoom);
+
+    const container = this.getContainer();
+    const contentX = point.percent
+      ? (point.x / 100) * container.clientWidth
+      : point.x;
+    const contentY = point.percent
+      ? (point.y / 100) * container.clientHeight
+      : point.y;
+
+    const offsetToCenter = this.getContentPointOffsetToCenter(
+      contentX,
+      contentY
+    );
+    this.adjustPositionByZoom(zoom, offsetToCenter.x, offsetToCenter.y);
+    this.zoom = zoom;
+    this.setPosition(instant);
+
+    this.fireEvent('onZoom', this.getPosition());
     return this;
   }
 

--- a/src/core/domPanZoom.js
+++ b/src/core/domPanZoom.js
@@ -86,30 +86,10 @@ export default class domPanZoom {
     // Attach events
     this.attachEvents();
 
-    // Adjust minZoom for option bounds
-    if (this.options.bounds) {
-      const maxWidth = wrapper.clientWidth;
-      const maxHeight = wrapper.clientHeight;
-
-      const panZoomWidth = container.clientWidth;
-      const panZoomHeight = container.clientHeight;
-
-      const minZoomX = maxWidth / panZoomWidth;
-      const minZoomY = maxHeight / panZoomHeight;
-
-      if (this.options.bounds == 'cover') {
-        this.options.minZoom = Math.max(
-          this.options.minZoom,
-          minZoomX,
-          minZoomY
-        );
-      } else {
-        this.options.minZoom = Math.max(
-          this.options.minZoom,
-          Math.min(minZoomX, minZoomY)
-        );
-      }
-    }
+    // Store base zoom limits before bounds adjustment
+    this.baseMinZoom = this.options.minZoom;
+    this.baseMaxZoom = this.options.maxZoom;
+    this.adjustMinZoomForBounds();
 
     // Set initial zoom
     this.zoom = this.sanitizeZoom(this.options.initialZoom);
@@ -132,6 +112,56 @@ export default class domPanZoom {
   // Fire an event from the options
   fireEvent(event, pass) {
     this.options[event] && this.options[event].bind(this)(pass);
+  }
+
+  // Recalculate minZoom from bounds and the configured base minZoom
+  adjustMinZoomForBounds() {
+    this.options.minZoom = this.baseMinZoom;
+    this.options.maxZoom = this.baseMaxZoom;
+
+    if (!this.options.bounds) {
+      return;
+    }
+
+    const wrapper = this.getWrapper();
+    const container = this.getContainer();
+    if (!wrapper || !container) {
+      return;
+    }
+
+    const maxWidth = wrapper.clientWidth;
+    const maxHeight = wrapper.clientHeight;
+    const panZoomWidth = container.clientWidth;
+    const panZoomHeight = container.clientHeight;
+
+    if (!panZoomWidth || !panZoomHeight) {
+      return;
+    }
+
+    const minZoomX = maxWidth / panZoomWidth;
+    const minZoomY = maxHeight / panZoomHeight;
+
+    if (this.options.bounds == 'cover') {
+      this.options.minZoom = Math.max(
+        this.options.minZoom,
+        minZoomX,
+        minZoomY
+      );
+    } else {
+      this.options.minZoom = Math.max(
+        this.options.minZoom,
+        Math.min(minZoomX, minZoomY)
+      );
+    }
+  }
+
+  // Recalculate bounds after the wrapper or panZoom element changes size
+  resize() {
+    const zoom = this.zoom;
+    this.adjustMinZoomForBounds();
+    this.zoom = this.sanitizeZoom(zoom);
+    this.setPosition(true);
+    return this;
   }
 
   // Attach events

--- a/src/core/domPanZoom.js
+++ b/src/core/domPanZoom.js
@@ -36,6 +36,9 @@ export default class domPanZoom {
       // When true or a function, require a modifier key before wheel zoom
       mouseWheelRequiresKey: false,
 
+      // Zoom in on double-click
+      dblClickZoomEnabled: false,
+
       // The speed in which to zoom when pinching with touch gestures
       // TODO this seems to not work correctly
       zoomSpeedPinch: 4,
@@ -307,6 +310,26 @@ export default class domPanZoom {
     };
 
     this.getWrapper().addEventListener('wheel', mouseWheelEvent, {
+      passive: false
+    });
+
+    const doubleClickEvent = (ev) => {
+      if (!this.options.dblClickZoomEnabled || !this.options.zoomEnabled) {
+        return;
+      }
+
+      ev.preventDefault();
+
+      const zoomStep = (100 + this.options.zoomStep) / 100;
+      const nextZoom = this.sanitizeZoom(this.zoom * zoomStep);
+      const offsetToCenter = this.getEventOffsetToCenter(ev);
+      this.adjustPositionByZoom(nextZoom, offsetToCenter.x, offsetToCenter.y);
+      this.zoom = nextZoom;
+      this.setPosition(true);
+      this.fireEvent('onZoom', this.getPosition());
+    };
+
+    this.getWrapper().addEventListener('dblclick', doubleClickEvent, {
       passive: false
     });
 

--- a/src/core/domPanZoom.js
+++ b/src/core/domPanZoom.js
@@ -20,6 +20,10 @@ export default class domPanZoom {
       minZoom: 0.1,
       maxZoom: 10,
 
+      // Enable or disable user panning and zooming
+      panEnabled: true,
+      zoomEnabled: true,
+
       // How many percent to pan by default with the panning methods panLeft, panRight, panUp and panDown
       panStep: 10,
 
@@ -75,7 +79,7 @@ export default class domPanZoom {
     const container = this.getContainer();
 
     // Add styles
-    wrapper.style.cursor = 'grab';
+    this.updateInteractionCursor();
     wrapper.style.overflow = 'hidden';
 
     // Cache
@@ -107,6 +111,16 @@ export default class domPanZoom {
 
     // Trigger event
     this.fireEvent('onInit', this.getPosition());
+  }
+
+  // Update the wrapper cursor based on panEnabled
+  updateInteractionCursor() {
+    const wrapper = this.getWrapper();
+    if (!wrapper) {
+      return;
+    }
+
+    wrapper.style.cursor = this.options.panEnabled ? 'grab' : null;
   }
 
   // Fire an event from the options
@@ -168,7 +182,7 @@ export default class domPanZoom {
   attachEvents() {
     // Event while mouse moving
     const setPositionEvent = (ev) => {
-      if (this.blockPan == true) {
+      if (this.blockPan == true || !this.options.panEnabled) {
         return;
       }
 
@@ -197,6 +211,10 @@ export default class domPanZoom {
 
     // Mouse down or touchstart event
     const mouseDownTouchStartEvent = (ev) => {
+      if (!this.options.panEnabled) {
+        return;
+      }
+
       ev.preventDefault();
       document.body.style.cursor = 'grabbing';
       this.getWrapper().style.cursor = 'grabbing';
@@ -219,7 +237,7 @@ export default class domPanZoom {
     const mouseUpTouchEndEvent = () => {
       this.previousEvent = null;
       document.body.style.cursor = null;
-      this.getWrapper().style.cursor = 'grab';
+      this.updateInteractionCursor();
       document.removeEventListener('mousemove', setPositionEvent, {
         passive: true
       });
@@ -237,6 +255,10 @@ export default class domPanZoom {
 
     // Mouse wheel events
     const mouseWheelEvent = (ev) => {
+      if (!this.options.zoomEnabled) {
+        return;
+      }
+
       ev.preventDefault();
 
       // Delta
@@ -302,7 +324,7 @@ export default class domPanZoom {
       }
 
       // Proceed if two touch gestures detected
-      if (this.evCache.length == 2) {
+      if (this.evCache.length == 2 && this.options.zoomEnabled) {
         // Calculate distance between fingers
         let pinchDiff = this.getTouchEventsDistance(
           this.evCache[0],

--- a/src/core/domPanZoom.js
+++ b/src/core/domPanZoom.js
@@ -33,6 +33,9 @@ export default class domPanZoom {
       // The speed in which to zoom when using mouse wheel
       zoomSpeedWheel: 1,
 
+      // When true or a function, require a modifier key before wheel zoom
+      mouseWheelRequiresKey: false,
+
       // The speed in which to zoom when pinching with touch gestures
       // TODO this seems to not work correctly
       zoomSpeedPinch: 4,
@@ -121,6 +124,18 @@ export default class domPanZoom {
     }
 
     wrapper.style.cursor = this.options.panEnabled ? 'grab' : null;
+  }
+
+  // Check whether wheel zoom is allowed for the current event
+  isMouseWheelZoomAllowed(ev) {
+    const requirement = this.options.mouseWheelRequiresKey;
+    if (!requirement) {
+      return true;
+    }
+    if (typeof requirement === 'function') {
+      return requirement(ev);
+    }
+    return ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey;
   }
 
   // Fire an event from the options
@@ -256,6 +271,10 @@ export default class domPanZoom {
     // Mouse wheel events
     const mouseWheelEvent = (ev) => {
       if (!this.options.zoomEnabled) {
+        return;
+      }
+
+      if (!this.isMouseWheelZoomAllowed(ev)) {
         return;
       }
 

--- a/src/core/domPanZoom.js
+++ b/src/core/domPanZoom.js
@@ -434,6 +434,52 @@ export default class domPanZoom {
         });
       }
     );
+
+    this._handlers = {
+      setPositionEvent,
+      mouseDownTouchStartEvent,
+      mouseUpTouchEndEvent,
+      mouseWheelEvent,
+      doubleClickEvent,
+      pointerDownEvent,
+      pointerMoveEvent,
+      pointerUpEvent
+    };
+  }
+
+  // Remove event listeners so the instance can be replaced safely
+  destroy() {
+    if (this._destroyed) {
+      return this;
+    }
+
+    const wrapper = this.getWrapper();
+    const handlers = this._handlers;
+
+    if (wrapper && handlers) {
+      wrapper.removeEventListener('mousedown', handlers.mouseDownTouchStartEvent);
+      wrapper.removeEventListener('touchstart', handlers.mouseDownTouchStartEvent);
+      wrapper.removeEventListener('wheel', handlers.mouseWheelEvent);
+      wrapper.removeEventListener('dblclick', handlers.doubleClickEvent);
+      wrapper.removeEventListener('pointerdown', handlers.pointerDownEvent);
+      wrapper.removeEventListener('pointermove', handlers.pointerMoveEvent);
+
+      ['pointerup', 'pointercancel', 'pointerout', 'pointerleave'].forEach(
+        (event) => {
+          wrapper.removeEventListener(event, handlers.pointerUpEvent);
+        }
+      );
+    }
+
+    if (handlers) {
+      document.removeEventListener('mouseup', handlers.mouseUpTouchEndEvent);
+      document.removeEventListener('touchend', handlers.mouseUpTouchEndEvent);
+      document.removeEventListener('mousemove', handlers.setPositionEvent);
+      document.removeEventListener('touchmove', handlers.setPositionEvent);
+    }
+
+    this._destroyed = true;
+    return this;
   }
 
   // https://stackoverflow.com/questions/8389156/what-substitute-should-we-use-for-layerx-layery-since-they-are-deprecated-in-web

--- a/svgMap-compatibility-part-1.md
+++ b/svgMap-compatibility-part-1.md
@@ -1,0 +1,158 @@
+# svgMap compatibility — Phase 1
+
+Phase 1 adds dom-pan-zoom APIs needed to replace svg-pan-zoom in [svgMap](https://github.com/stephanwagner/svgMap). Changes are on branch `feat/svgMap-compatibility-high-relevance` as seven atomic commits (highest relevance first).
+
+---
+
+## 1. `resize()` + `adjustMinZoomForBounds()` (`85d1cf1`)
+
+**Problem:** svg-pan-zoom had `resize()`. svgMap calls it when `resetZoomOnResize` is true — a `ResizeObserver` on the map wrapper triggers `mapPanZoom.resize()` then reset. dom-pan-zoom had no equivalent, and its init logic permanently overwrote `options.minZoom` when `bounds` was set, so there was no way to recalculate on layout change.
+
+**What changed:**
+
+- **`baseMinZoom` / `baseMaxZoom`** — store the user's original limits before bounds adjustment.
+- **`adjustMinZoomForBounds()`** — extracted the init-time math that raises `minZoom` so the content fits the wrapper (`contain` vs `cover`).
+- **`resize()`** — re-runs that calculation, clamps the current zoom to the new limits, and reapplies the transform instantly.
+
+**Why it matters for svgMap:** Without this, resizing the map container would leave stale zoom limits and broken pan bounds.
+
+---
+
+## 2. `reset()` (`430cde3`)
+
+**Problem:** svg-pan-zoom's `reset()` restores the initial view. svgMap uses it for the zoom-reset button, continent "World" selection, and as the first step before continent zoom.
+
+**What changed:** New method that restores initial zoom and pan:
+
+```javascript
+reset(true)                          // instant reset to defaults
+reset({ zoom: 1.9, instant: true })  // override zoom/pan
+```
+
+It reads from constructor options (`initialZoom`, `initialPanX/Y`, `center`), applies zoom first, then centers or pans, then calls `setPosition`. Fires `onZoom` and `onPan`.
+
+**Why it matters for svgMap:** Direct replacement for `this.mapPanZoom.reset()` in `zoomMap('reset')` and `zoomContinent()`.
+
+---
+
+## 3. `zoomToAt()` + `getContentPointOffsetToCenter()` (`54fa992`)
+
+**Problem:** svg-pan-zoom's `zoomAtPoint(zoom, { x, y })` zooms to a level while keeping a point fixed on screen. svgMap uses this for:
+
+- **Continent selector** — e.g. Africa at `{ x: 454, y: 250 }` in SVG viewBox space
+- **`initialPan`** — `zoomAtPointBy(initialZoom, initialPan)`
+
+dom-pan-zoom only had `zoomTo()`, which zooms toward the **center** of the wrapper, not an arbitrary point.
+
+**What changed:**
+
+- **`getContentPointOffsetToCenter(contentX, contentY)`** — same math as wheel zoom (`getEventOffsetToCenter`), but for a point in the panZoom element's coordinate space (pixels from top-left of the unscaled element).
+- **`zoomToAt(zoom, point, instant)`** — zooms to `zoom` while keeping that point fixed, using the existing `adjustPositionByZoom()` logic.
+
+Supports two coordinate modes:
+
+```javascript
+zoomToAt(1.9, { x: 454, y: 250 })                // pixels in content space
+zoomToAt(1.9, { x: 22.7, y: 25, percent: true }) // percent of content size
+```
+
+**Why it matters for svgMap:** Continent presets and `initialPan` can be mapped from SVG viewBox coords to content pixels, then passed here instead of svg-pan-zoom's `zoomAtPoint`.
+
+---
+
+## 4. `panEnabled` and `zoomEnabled` (`73d7ae8`)
+
+**Problem:** svg-pan-zoom has `panEnabled` and `zoomEnabled`. svgMap maps `allowInteraction: false` to both, disabling user drag/wheel while keeping programmatic zoom (buttons) working.
+
+**What changed:**
+
+- Two new options, both default `true`.
+- **Event gating only** — drag, wheel, and pinch handlers check these flags; `zoomIn()`, `zoomTo()`, `reset()`, etc. are **not** blocked.
+- **`updateInteractionCursor()`** — sets `cursor: grab` only when `panEnabled` is true; restores default cursor otherwise.
+
+**Why it matters for svgMap:** One-line mapping: `panEnabled: allowInteraction, zoomEnabled: allowInteraction`.
+
+---
+
+## 5. `mouseWheelRequiresKey` (`627576e`)
+
+**Problem:** svgMap's `mouseWheelZoomWithKey` option shows a "press ALT/COMMAND to zoom" notice and only allows wheel zoom when a modifier key is held. svg-pan-zoom didn't handle this natively either — svgMap layered its own key tracking via a `svgMap-zoom-key-pressed` body class — but dom-pan-zoom's wheel handler always called `preventDefault()`, which would block page scroll even when zoom wasn't intended.
+
+**What changed:**
+
+- New option `mouseWheelRequiresKey`, default `false`.
+- **`isMouseWheelZoomAllowed(ev)`** helper:
+  - `false` → wheel zoom always allowed (existing behavior)
+  - `true` → requires alt, control, meta, or shift on the event
+  - **function** → custom check, e.g. `() => document.body.classList.contains('svgMap-zoom-key-pressed')`
+- When not allowed, the wheel handler **returns early without `preventDefault`**, so the page can scroll normally.
+
+**Why it matters for svgMap:** svgMap can pass a function that checks its existing key UI, without duplicating wheel logic.
+
+---
+
+## 6. `dblClickZoomEnabled` (`e8e440b`)
+
+**Problem:** svgMap exposes `dblClickZoomEnabled` (default `true`) and passes it to svg-pan-zoom. dom-pan-zoom had no double-click handler.
+
+**What changed:**
+
+- New option `dblClickZoomEnabled`, default `false` (conservative default for generic dom-pan-zoom users).
+- `dblclick` listener on the wrapper: when enabled and `zoomEnabled` is true, zooms in by one `zoomStep` at the cursor position (same focal-point math as wheel zoom).
+
+**Why it matters for svgMap:** Direct mapping: `dblClickZoomEnabled: this.options.dblClickZoomEnabled`.
+
+---
+
+## 7. README documentation (`76093ee`)
+
+**Problem:** The new API wasn't documented; the README also had a few inaccuracies (`zoomWheelSpeed` vs actual `zoomSpeedWheel`, `bounds` default listed as `cover` vs code's `'contain'`).
+
+**What changed:** Documented all new options and methods (`resize`, `reset`, `zoomToAt`, `panEnabled`, `zoomEnabled`, `mouseWheelRequiresKey`, `dblClickZoomEnabled`) and corrected the existing option names/defaults.
+
+---
+
+## Summary: svg-pan-zoom → dom-pan-zoom mapping
+
+| svgMap / svg-pan-zoom | dom-pan-zoom (Phase 1) |
+|-----------------------|------------------------|
+| `resize()` | `resize()` |
+| `reset()` | `reset()` |
+| `zoomAtPoint(z, point)` | `zoomToAt(z, point)` |
+| `zoomAtPointBy(z, point)` | `zoomToAt(z, point)` after computing target zoom |
+| `panEnabled` / `zoomEnabled` | same option names |
+| `mouseWheelZoomWithKey` | `mouseWheelRequiresKey: () => …` |
+| `dblClickZoomEnabled` | same option name |
+
+---
+
+## svgMap integration preview (Phase 2)
+
+```javascript
+this.mapPanZoom = new domPanZoom({
+  wrapperElement: this.mapWrapper,
+  panZoomElement: this.mapImage,
+  minZoom: this.options.minZoom,
+  maxZoom: this.options.maxZoom,
+  bounds: 'contain',
+  center: true,
+  initialZoom: this.options.initialZoom,
+  zoomSpeedWheel: this.options.zoomScaleSensitivity,
+  panEnabled: this.options.allowInteraction,
+  zoomEnabled: this.options.allowInteraction,
+  dblClickZoomEnabled: this.options.dblClickZoomEnabled,
+  mouseWheelRequiresKey: this.options.mouseWheelZoomWithKey
+    ? () => document.body.classList.contains('svgMap-zoom-key-pressed')
+    : false,
+  onZoom: () => this.setControlStatuses()
+});
+
+// Continent zoom (viewBox → content pixels)
+this.mapPanZoom.reset(true);
+this.mapPanZoom.zoomToAt(continent.zoom, {
+  x: (continent.pan.x / 2000) * this.mapImage.clientWidth,
+  y: (continent.pan.y / 1001) * this.mapImage.clientHeight
+}, true);
+```
+
+Nothing in Phase 1 touched svgMap itself — these are upstream dom-pan-zoom changes, ready for Phase 2 integration.

--- a/svgMap-compatibility-part-1.md
+++ b/svgMap-compatibility-part-1.md
@@ -112,6 +112,19 @@ zoomToAt(1.9, { x: 22.7, y: 25, percent: true }) // percent of content size
 
 ---
 
+## 8. `destroy()` (`e22e43c`)
+
+**Problem:** Creating a new domPanZoom on the same wrapper without cleanup stacked event listeners. Options on the new instance (e.g. `zoomEnabled: false`) appeared ignored because old handlers still ran.
+
+**What changed:**
+
+- **`destroy()`** — removes all wrapper and document event listeners attached by the instance.
+- Safe to call multiple times; returns the instance for chaining.
+
+**Why it matters for svgMap:** Required when re-initing pan/zoom on the same map DOM (e.g. option changes, SPA remounts, or test harnesses that call Apply). svgMap should call `this.mapPanZoom.destroy()` before replacing the instance if map creation runs more than once on the same elements.
+
+---
+
 ## Summary: svg-pan-zoom → dom-pan-zoom mapping
 
 | svgMap / svg-pan-zoom | dom-pan-zoom (Phase 1) |
@@ -123,6 +136,7 @@ zoomToAt(1.9, { x: 22.7, y: 25, percent: true }) // percent of content size
 | `panEnabled` / `zoomEnabled` | same option names |
 | `mouseWheelZoomWithKey` | `mouseWheelRequiresKey: () => …` |
 | `dblClickZoomEnabled` | same option name |
+| Re-init on same DOM | `destroy()` before `new domPanZoom(...)` |
 
 ---
 

--- a/test/domPanZoom.api.test.js
+++ b/test/domPanZoom.api.test.js
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createFixture, getTransform, setLayoutSize } from './helpers.js';
+
+describe('domPanZoom API', () => {
+  /** @type {ReturnType<typeof createFixture>[]} */
+  const fixtures = [];
+
+  afterEach(() => {
+    while (fixtures.length) {
+      fixtures.pop().destroy();
+    }
+  });
+
+  function setup(options) {
+    const fixture = createFixture(options);
+    fixtures.push(fixture);
+    return fixture;
+  }
+
+  it('initializes with the configured zoom and centered pan', () => {
+    const { instance } = setup({ initialZoom: 1.5 });
+
+    expect(instance.getZoom()).toBe(1.5);
+    expect(instance.getPan().x).toBeCloseTo(50, 1);
+    expect(instance.getPan().y).toBeCloseTo(50, 1);
+  });
+
+  it('reset restores the initial zoom and pan', () => {
+    const { instance } = setup({ initialZoom: 1.5 });
+
+    instance.zoomTo(3, true);
+    instance.panTo(20, 80, true);
+
+    instance.reset(true);
+
+    expect(instance.getZoom()).toBe(1.5);
+    expect(instance.getPan().x).toBeCloseTo(50, 1);
+    expect(instance.getPan().y).toBeCloseTo(50, 1);
+  });
+
+  it('reset accepts option overrides', () => {
+    const { instance } = setup({ initialZoom: 1, center: false, initialPanX: 10, initialPanY: 20 });
+
+    instance.reset({ zoom: 2, panX: 30, panY: 40, instant: true });
+
+    expect(instance.getZoom()).toBe(2);
+    expect(instance.getPan().x).toBeCloseTo(30, 1);
+    expect(instance.getPan().y).toBeCloseTo(40, 1);
+  });
+
+  it('resize reclamps zoom when bounds minZoom increases', () => {
+    const { wrapper, content, instance } = setup({
+      bounds: 'contain',
+      minZoom: 0.1,
+      initialZoom: 1
+    });
+
+    setLayoutSize(wrapper, 400, 200);
+    setLayoutSize(content, 800, 400);
+
+    instance.resize();
+    const zoomAfterShrink = instance.getZoom();
+
+    expect(zoomAfterShrink).toBeGreaterThanOrEqual(0.5);
+    expect(getTransform(content)).not.toBeNull();
+  });
+
+  it('zoomToAt changes zoom while updating the transform', () => {
+    const { content, instance } = setup({ initialZoom: 1 });
+
+    const before = getTransform(content);
+    instance.zoomToAt(2, { x: 100, y: 50 }, true);
+    const after = getTransform(content);
+
+    expect(instance.getZoom()).toBe(2);
+    expect(after.scaleX).toBe(2);
+    expect(after.translateX).not.toBe(before.translateX);
+    expect(after.translateY).not.toBe(before.translateY);
+  });
+
+  it('zoomToAt accepts percent coordinates', () => {
+    const { instance } = setup({ initialZoom: 1 });
+
+    instance.zoomToAt(2, { x: 25, y: 50, percent: true }, true);
+
+    expect(instance.getZoom()).toBe(2);
+  });
+
+  it('zoomIn and zoomOut change zoom relative to zoomStep', () => {
+    const { instance } = setup({ initialZoom: 1, zoomStep: 50 });
+
+    instance.zoomIn(true);
+    expect(instance.getZoom()).toBe(1.5);
+
+    instance.zoomOut(true);
+    expect(instance.getZoom()).toBe(1);
+  });
+});

--- a/test/domPanZoom.options.test.js
+++ b/test/domPanZoom.options.test.js
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import domPanZoom from '../src/index.js';
 import { createFixture, dispatchWheel } from './helpers.js';
 
 describe('domPanZoom options', () => {
@@ -122,5 +123,29 @@ describe('domPanZoom options', () => {
     );
 
     expect(instance.getZoom()).toBe(1);
+  });
+
+  it('destroy removes listeners so a replaced instance respects new options', () => {
+    const { wrapper, content, instance: first } = setup({
+      zoomEnabled: true,
+      initialZoom: 1
+    });
+
+    first.destroy();
+
+    const second = new domPanZoom({
+      wrapperElement: wrapper,
+      panZoomElement: content,
+      bounds: false,
+      initialZoom: 1,
+      center: true,
+      transitionSpeed: 0,
+      zoomEnabled: false
+    });
+
+    dispatchWheel(wrapper, { deltaY: -120 });
+
+    expect(second.getZoom()).toBe(1);
+    second.destroy();
   });
 });

--- a/test/domPanZoom.options.test.js
+++ b/test/domPanZoom.options.test.js
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createFixture, dispatchWheel } from './helpers.js';
+
+describe('domPanZoom options', () => {
+  /** @type {ReturnType<typeof createFixture>[]} */
+  const fixtures = [];
+
+  afterEach(() => {
+    while (fixtures.length) {
+      fixtures.pop().destroy();
+    }
+  });
+
+  function setup(options) {
+    const fixture = createFixture(options);
+    fixtures.push(fixture);
+    return fixture;
+  }
+
+  it('panEnabled false removes the grab cursor', () => {
+    const { wrapper } = setup({ panEnabled: false });
+
+    expect(wrapper.style.cursor).toBeFalsy();
+  });
+
+  it('panEnabled true sets the grab cursor', () => {
+    const { wrapper } = setup({ panEnabled: true });
+
+    expect(wrapper.style.cursor).toBe('grab');
+  });
+
+  it('zoomEnabled false ignores wheel zoom', () => {
+    const { wrapper, instance } = setup({ zoomEnabled: false, initialZoom: 1 });
+
+    dispatchWheel(wrapper, { deltaY: -120 });
+
+    expect(instance.getZoom()).toBe(1);
+  });
+
+  it('mouseWheelRequiresKey true blocks wheel zoom without a modifier', () => {
+    const { wrapper, instance } = setup({
+      mouseWheelRequiresKey: true,
+      initialZoom: 1
+    });
+
+    dispatchWheel(wrapper, { deltaY: -120 });
+
+    expect(instance.getZoom()).toBe(1);
+  });
+
+  it('mouseWheelRequiresKey true allows wheel zoom with a modifier', () => {
+    const { instance } = setup({
+      mouseWheelRequiresKey: true,
+      initialZoom: 1
+    });
+
+    expect(
+      instance.isMouseWheelZoomAllowed({ altKey: true, ctrlKey: false, metaKey: false, shiftKey: false })
+    ).toBe(true);
+    expect(
+      instance.isMouseWheelZoomAllowed({ altKey: false, ctrlKey: false, metaKey: false, shiftKey: false })
+    ).toBe(false);
+  });
+
+  it('wheel zoom works when mouseWheelRequiresKey is disabled', () => {
+    const { wrapper, instance } = setup({
+      mouseWheelRequiresKey: false,
+      initialZoom: 1
+    });
+
+    dispatchWheel(wrapper, { deltaY: -120 });
+
+    expect(instance.getZoom()).toBeGreaterThan(1);
+  });
+
+  it('mouseWheelRequiresKey accepts a custom function', () => {
+    const allowWheel = vi.fn(() => false);
+    const { wrapper, instance } = setup({
+      mouseWheelRequiresKey: allowWheel,
+      initialZoom: 1
+    });
+
+    dispatchWheel(wrapper, { deltaY: -120 });
+
+    expect(allowWheel).toHaveBeenCalled();
+    expect(instance.getZoom()).toBe(1);
+  });
+
+  it('dblClickZoomEnabled zooms in at the cursor position', () => {
+    const { wrapper, instance } = setup({
+      dblClickZoomEnabled: true,
+      initialZoom: 1,
+      zoomStep: 50
+    });
+
+    wrapper.dispatchEvent(
+      new MouseEvent('dblclick', {
+        clientX: 400,
+        clientY: 200,
+        bubbles: true,
+        cancelable: true
+      })
+    );
+
+    expect(instance.getZoom()).toBe(1.5);
+  });
+
+  it('dblClickZoomEnabled respects zoomEnabled false', () => {
+    const { wrapper, instance } = setup({
+      dblClickZoomEnabled: true,
+      zoomEnabled: false,
+      initialZoom: 1
+    });
+
+    wrapper.dispatchEvent(
+      new MouseEvent('dblclick', {
+        clientX: 400,
+        clientY: 200,
+        bubbles: true,
+        cancelable: true
+      })
+    );
+
+    expect(instance.getZoom()).toBe(1);
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,95 @@
+import domPanZoom from '../src/index.js';
+
+export function setLayoutSize(element, width, height) {
+  Object.assign(element.style, {
+    width: `${width}px`,
+    height: `${height}px`
+  });
+
+  for (const prop of ['offsetWidth', 'offsetHeight', 'clientWidth', 'clientHeight']) {
+    Object.defineProperty(element, prop, {
+      configurable: true,
+      get() {
+        return prop.includes('Width') ? width : height;
+      }
+    });
+  }
+}
+
+export function createFixture(options = {}) {
+  const wrapper = document.createElement('div');
+  const content = document.createElement('div');
+
+  Object.assign(wrapper.style, {
+    position: 'relative',
+    overflow: 'hidden'
+  });
+
+  setLayoutSize(wrapper, 800, 400);
+  setLayoutSize(content, 800, 400);
+
+  Object.defineProperty(content, 'offsetLeft', {
+    configurable: true,
+    value: 0
+  });
+  Object.defineProperty(content, 'offsetTop', {
+    configurable: true,
+    value: 0
+  });
+
+  wrapper.appendChild(content);
+  document.body.appendChild(wrapper);
+
+  const instance = new domPanZoom({
+    wrapperElement: wrapper,
+    panZoomElement: content,
+    bounds: false,
+    initialZoom: 1,
+    center: true,
+    transitionSpeed: 0,
+    ...options
+  });
+
+  return {
+    wrapper,
+    content,
+    instance,
+    destroy() {
+      wrapper.remove();
+    }
+  };
+}
+
+export function getTransform(content) {
+  const match = content.style.transform.match(
+    /matrix\(([^,]+),\s*([^,]+),\s*([^,]+),\s*([^,]+),\s*([^,]+),\s*([^)]+)\)/
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    scaleX: parseFloat(match[1]),
+    scaleY: parseFloat(match[4]),
+    translateX: parseFloat(match[5]),
+    translateY: parseFloat(match[6])
+  };
+}
+
+export function dispatchWheel(
+  target,
+  { deltaY = -100, altKey = false, clientX = 400, clientY = 200 } = {}
+) {
+  const event = new WheelEvent('wheel', {
+    deltaY,
+    altKey,
+    clientX,
+    clientY,
+    bubbles: true,
+    cancelable: true
+  });
+
+  target.dispatchEvent(event);
+  return event;
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -55,6 +55,7 @@ export function createFixture(options = {}) {
     content,
     instance,
     destroy() {
+      instance.destroy();
       wrapper.remove();
     }
   };

--- a/upcoming-fixes.md
+++ b/upcoming-fixes.md
@@ -1,0 +1,129 @@
+# Upcoming fixes & improvements
+
+Notes from a JavaScript best-practices review of dom-pan-zoom (post Phase 1 / svgMap compatibility work). Ordered by priority.
+
+---
+
+## High priority — bugs & lifecycle
+
+### 1. Fix math typos in touch/pan helpers
+
+| Location | Current | Likely fix |
+|----------|---------|------------|
+| `getTouchEventsDistance` | `ev1.pageX - ev1.pageX` | `ev1.pageX - ev2.pageX` |
+| `getTouchEventsCenter` | `ev1.pageY + ev2.pageX` | `ev1.pageY + ev2.pageY` (verify) |
+| `pan()` vertical step | uses `container.clientWidth` for height | use `container.clientHeight` |
+
+Pinch zoom and vertical pan may behave incorrectly until these are fixed.
+
+### 2. Fail fast in the constructor
+
+If `wrapperElement` or `panZoomElement` is missing or not found, getters log to `console.error` and return `null`, then `init()` can throw (e.g. `wrapper.style.overflow`). **Throw a clear `Error` in the constructor** instead of producing a half-broken instance.
+
+### 3. Scope document-level listeners to active interaction
+
+Each instance permanently attaches `mouseup` and `touchend` on `document`. With multiple instances on one page, every instance’s handler runs on any document mouseup.
+
+**Better:** attach document listeners only during an active drag/pinch; remove on release. (Partially done for `mousemove` / `touchmove`; `mouseup` / `touchend` still global and permanent.)
+
+### 4. Separate user config from computed state
+
+`adjustMinZoomForBounds()` mutates `this.options.minZoom` / `maxZoom`. That blurs “what the user passed” vs “what bounds math computed”.
+
+**Better:** keep `baseMinZoom` / `baseMaxZoom` (already stored) and use `effectiveMinZoom` / `effectiveMaxZoom` (or recompute in `sanitizeZoom`) without overwriting `this.options`.
+
+---
+
+## Medium priority — API & consistency
+
+### 5. Use `AbortController` in `destroy()`
+
+`destroy()` manually removes eight handler references. **Alternative:** pass `{ signal: this._abort.signal }` to all `addEventListener` calls; `destroy()` calls `this._abort.abort()`. Simpler and harder to leak a listener.
+
+### 6. Guard against double `init()`
+
+Calling `init()` twice (or constructing twice without `destroy()`) stacks listeners again. Add `if (this._initialized) return` or make re-init explicit via a documented `update()` path.
+
+### 7. Standardize overloaded method signatures
+
+Patterns like `zoomIn(true)`, `reset({ zoom: 2 })`, `panLeft(50, true)` are flexible but easy to misuse. Consider options objects consistently before a 1.0 API freeze:
+
+```javascript
+zoomIn({ step: 50, instant: true })
+```
+
+### 8. Use strict equality
+
+Replace `==` with `===` for `bounds`, `zoom` string checks (`'cover'`, `'contain'`), etc., unless loose equality is intentional.
+
+### 9. Replace side-effect expressions with `if` blocks
+
+Examples in `setPosition` and `pan`:
+
+```javascript
+this.x < upperOffsetX && (this.x = upperOffsetX);
+direction === 'left' && (this.x += panWidth * -1);
+```
+
+Clearer as normal `if` statements for readability and debugging.
+
+### 10. Extract shared bounds / fit math
+
+Fit/contain min-zoom logic appears in `adjustMinZoomForBounds()`, `sanitizeZoom()`, and related clamping in `setPosition()`. A single pure helper (e.g. `computeFitZoom(wrapper, container, mode)`) would reduce drift and is easy to unit test.
+
+### 11. Remove or implement `preferPageScroll`
+
+Option exists in defaults but is not wired up. Either implement (page scroll vs zoom/pan) or remove from defaults and README to avoid confusing library users.
+
+---
+
+## Lower priority — polish & DX
+
+### 12. JSDoc or TypeScript definitions
+
+Public options and methods would benefit from `/** @param ... */` comments or a shipped `.d.ts`. High value for svgMap and other consumers; low implementation cost.
+
+### 13. Class naming
+
+Class is `domPanZoom` (camelCase) rather than conventional `DomPanZoom`. May be intentional for UMD global name — document if so.
+
+### 14. Transform string building
+
+`matrix(...)` via string concat works. Could use `translate() scale()` or template literals; optional `will-change: transform` if jank appears on large content.
+
+### 15. Cache event callback bindings
+
+`fireEvent` calls `.bind(this)` on every invocation. Negligible at current scale; could bind once in constructor if callbacks become hot paths.
+
+---
+
+## Already addressed in Phase 1 (keep)
+
+| Change | Why it matters |
+|--------|----------------|
+| `destroy()` + stored `_handlers` | Required lifecycle for re-init on same DOM (tester, SPAs) |
+| Test for re-init / `zoomEnabled` | Regression coverage for stacked listeners |
+| `let` in `zoomInOut` | Fixed `zoomOut()` crash |
+| `mouseWheelRequiresKey` as `boolean \| function` | Extensible without forking (svgMap key UI) |
+| Vitest + happy-dom | Catches API regressions before publish |
+
+---
+
+## Suggested order of work
+
+1. Fix math typos (#1)
+2. Constructor validation (#2)
+3. Document listener scoping (#3)
+4. Split computed vs user zoom limits (#4)
+5. JSDoc on public API (#12)
+6. `AbortController` refactor (#5)
+7. Remaining consistency items as time allows
+
+---
+
+## Out of scope (for now)
+
+- Full TypeScript rewrite
+- Rewriting event model (pointer vs mouse/touch split)
+- Breaking API rename (`DomPanZoom`, options object only)
+- Playwright / browser E2E (Vitest covers programmatic API sufficiently for now)

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['test/**/*.test.js']
+  }
+});


### PR DESCRIPTION
> [!TIP]
> I created a small tester to tryout dom-pan-zoom locally
> https://github.com/m1rm/dom-pan-zoom-tester

> [!CAUTION]
> Co-authored by Cursor IDE using "auto" mode
> I tested everything manually with my tester-project as
> well as checking the code of course

### Changes

| Commit | Change | Why needed |
|--------|--------|------------|
| `85d1cf1` | Add `resize()` and extract `adjustMinZoomForBounds()` | svgMap calls `resize()` on container resize; dom-pan-zoom had no way to recalculate bounds-adjusted `minZoom` after layout changes |
| `430cde3` | Add `reset()` to restore initial zoom and pan | Direct replacement for svg-pan-zoom's `reset()`, used by svgMap's zoom-reset button and continent selector |
| `54fa992` | Add `zoomToAt()` and `getContentPointOffsetToCenter()` | Replaces svg-pan-zoom's `zoomAtPoint` / `zoomAtPointBy` for continent zoom and `initialPan` focal zoom |
| `73d7ae8` | Add `panEnabled` and `zoomEnabled` options | Maps to svgMap's `allowInteraction: false` — disables user drag/wheel/pinch while keeping programmatic zoom working |
| `627576e` | Add `mouseWheelRequiresKey` option | Maps to svgMap's `mouseWheelZoomWithKey`; supports a custom function and skips `preventDefault` when zoom is blocked so the page can scroll |
| `e8e440b` | Add `dblClickZoomEnabled` option | Maps to svgMap's existing `dblClickZoomEnabled` option |
| `76093ee` | Document new options and methods in README | Documents Phase 1 API; fixes incorrect README defaults (`bounds`, `zoomSpeedWheel`) |
| `b3354f3` | Add `svgMap-compatibility-part-1.md` | Maintainer-facing write-up of Phase 1 changes and svgMap integration mapping (repo only, not published) |
| `9ad4b4b` | Fix `zoomOut` crash and empty cursor when pan is disabled | `zoomInOut` reassigned a `const`; `cursor: null` rendered as `"null"` in the DOM — found while adding tests |
| `543a87b` | Add Vitest with happy-dom; wire `npm test` into `prepublishOnly` | Automated regression coverage for Phase 1 APIs |
| `8f71212` | Add API tests (`reset`, `resize`, `zoomToAt`, zoom controls) + fixture helper | Protects highest-risk svgMap migration APIs |
| `dc5cd3d` | Add option tests (`panEnabled`, `zoomEnabled`, `mouseWheelRequiresKey`, `dblClickZoomEnabled`) | Covers interaction gating without flaky full wheel-event simulation |
| `e22e43c` | Add `destroy()` to remove listeners when replacing an instance | Fixes stacked handlers when re-initing on the same wrapper — options like `zoomEnabled` appeared ignored after Apply in the tester |


### Next steps
Since this pull request is already quite huge, I added "upcoming-fixes.md" which I will tackle in the next pull request after this one.

### Reason for Changes
https://github.com/stephanwagner/svgMap/issues/208